### PR TITLE
Enable simultaneous control of multiple Feedback360 servos

### DIFF
--- a/examples/MultiMotors/MultiMotors.ino
+++ b/examples/MultiMotors/MultiMotors.ino
@@ -1,0 +1,29 @@
+#include "FeedBackServo.h"
+// define feedback signal pin
+#define FEEDBACK_PIN1 2
+#define FEEDBACK_PIN2 3
+
+// set feedback signal pin number
+FeedBackServo servo1 = FeedBackServo(FEEDBACK_PIN1);
+FeedBackServo servo2 = FeedBackServo(FEEDBACK_PIN2);
+
+void setup()
+{
+    Serial.begin(115200);
+
+    servo1.SetServoControl(9);
+    servo2.SetServoControl(10);
+
+    servo1.SetTarget(500);
+    servo2.SetTarget(5000);
+}
+
+void loop() 
+{  
+    servo1.Update();
+    servo2.Update();
+
+    Serial.print(servo1.Angle());
+    Serial.print(" / ");
+    Serial.println(servo2.Angle());
+}

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -69,32 +69,6 @@ void FeedBackServo::SetTarget(int target)
     targetAngle_ = target;
 }
 
-void FeedBackServo::rotate(int degree, int threshold)
-{
-    float output, offset, value;
-    for (int errorAngle = degree - angle;
-         abs(errorAngle) > threshold;
-         errorAngle = degree - angle)
-    {
-        output = errorAngle * Kp;
-        if (output > 200.0)
-            output = 200.0;
-        if (output < -200.0)
-            output = -200.0;
-        if (errorAngle > 0)
-            offset = 30.0;
-        else if (errorAngle < 0)
-            offset = -30.0;
-        else
-            offset = 0.0;
-
-        value = output + offset;
-        Parallax.writeMicroseconds(1490 - value);
-    }
-    Parallax.writeMicroseconds(1490);
-}
-
-
 void FeedBackServo::Update(int threshold = 4)
 {
     if (isActive_ == false) return;

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -18,7 +18,7 @@ FeedBackServo* FeedBackServo::instances[6] = { nullptr };
 FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
 {
     // feedback pin number validation
-    pinCheck(_feedbackPinNumber);
+    CheckPin(_feedbackPinNumber);
     feedbackPinNumber = _feedbackPinNumber;
 
     // convert feedback pin number to interrupt number for use on attachInterrupt function
@@ -38,15 +38,15 @@ FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
     }
 }
 
-void FeedBackServo::setServoControl(byte servoPinNumber)
+void FeedBackServo::SetServoControl(byte servoPinNumber)
 {
     // Servo control pin attach
     Parallax.attach(servoPinNumber);
 }
 
-void FeedBackServo::setKp(float _Kp)
+void FeedBackServo::SetKp(float Kp)
 {
-    FeedBackServo::Kp = _Kp;
+    FeedBackServo::Kp_ = Kp;
 }
 
 void FeedBackServo::SetActive(bool isActive)
@@ -82,7 +82,7 @@ int FeedBackServo::Angle()
     return angle;
 }
 
-void FeedBackServo::pinCheck(byte _feedbackPinNumber)
+void FeedBackServo::CheckPin(byte _feedbackPinNumber)
 {
 // Check pin number
 #ifdef ARDUINO_AVR_UNO

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -23,6 +23,8 @@ const int FeedBackServo::dutyScale = 1;
 const int FeedBackServo::q2min = unitsFC / 4;
 const int FeedBackServo::q3max = q2min * 3;
 
+FeedBackServo* FeedBackServo::instances[6] = { nullptr };
+
 FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
 {
     // feedback pin number validation
@@ -30,9 +32,20 @@ FeedBackServo::FeedBackServo(byte _feedbackPinNumber)
     feedbackPinNumber = _feedbackPinNumber;
 
     // convert feedback pin number to interrupt number for use on attachInterrupt function
-    byte internalPinNumber = digitalPinToInterrupt(feedbackPinNumber);
+    interruptNumber = digitalPinToInterrupt(feedbackPinNumber);
 
-    attachInterrupt(internalPinNumber, feedback, CHANGE);
+    if (interruptNumber < 6) {
+        instances[interruptNumber] = this;
+        switch (interruptNumber)
+        {
+        case 0: attachInterrupt(0, isr0, CHANGE); break;
+        case 1: attachInterrupt(1, isr1, CHANGE); break;
+        case 2: attachInterrupt(2, isr2, CHANGE); break;
+        case 3: attachInterrupt(3, isr3, CHANGE); break;
+        case 4: attachInterrupt(4, isr4, CHANGE); break;
+        case 5: attachInterrupt(5, isr5, CHANGE); break;
+        }
+    }
 }
 
 void FeedBackServo::setServoControl(byte servoPinNumber)
@@ -94,7 +107,7 @@ void FeedBackServo::pinCheck(byte _feedbackPinNumber)
 #endif
 }
 
-void FeedBackServo::feedback()
+void FeedBackServo::HandleFeedback()
 {
     if (digitalRead(feedbackPinNumber))
     {
@@ -131,3 +144,11 @@ void FeedBackServo::feedback()
         tHigh = fall - rise;
     }
 }
+
+// ISR delegates
+void FeedBackServo::isr0() { if (instances[0]) instances[0]->HandleFeedback(); }
+void FeedBackServo::isr1() { if (instances[1]) instances[1]->HandleFeedback(); }
+void FeedBackServo::isr2() { if (instances[2]) instances[2]->HandleFeedback(); }
+void FeedBackServo::isr3() { if (instances[3]) instances[3]->HandleFeedback(); }
+void FeedBackServo::isr4() { if (instances[4]) instances[4]->HandleFeedback(); }
+void FeedBackServo::isr5() { if (instances[5]) instances[5]->HandleFeedback(); }

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -66,7 +66,7 @@ void FeedBackServo::Update(int threshold = 4)
     int errorAngle = targetAngle_ - angle_;
     if (abs(errorAngle) <= threshold)
     {
-        servo.writeMicroseconds(1490);
+        Parallax.writeMicroseconds(1490);
         return;
     }
 
@@ -74,12 +74,12 @@ void FeedBackServo::Update(int threshold = 4)
     float offset = (errorAngle > 0) ? 30.0 : -30.0;
     float value = output + offset;
 
-    servo.writeMicroseconds(1490 - value);
+    Parallax.writeMicroseconds(1490 - value);
 }
 
 int FeedBackServo::Angle()
 {
-    return angle;
+    return angle_;
 }
 
 void FeedBackServo::CheckPin(byte _feedbackPinNumber)
@@ -125,9 +125,9 @@ void FeedBackServo::HandleFeedback()
             turns--;
 
         if (turns >= 0)
-            angle = (turns * unitsFC) + theta;
+            angle_ = (turns * unitsFC) + theta;
         else if (turns < 0)
-            angle = ((turns + 1) * unitsFC) - (unitsFC - theta);
+            angle_ = ((turns + 1) * unitsFC) - (unitsFC - theta);
 
         thetaPre = theta;
     }

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -8,20 +8,10 @@
 #include <Servo.h>
 #include "FeedBackServo.h"
 
-Servo FeedBackServo::Parallax;
-byte FeedBackServo::feedbackPinNumber = 2;
-volatile int FeedBackServo::angle;
-float FeedBackServo::thetaPre;
-unsigned int FeedBackServo::tHigh, FeedBackServo::tLow;
-unsigned long FeedBackServo::rise, FeedBackServo::fall;
-int FeedBackServo::turns = 0;
-float FeedBackServo::Kp = 1.0;
-const int FeedBackServo::unitsFC = 360;
 const float FeedBackServo::dcMin = 0.029;
 const float FeedBackServo::dcMax = 0.971;
-const int FeedBackServo::dutyScale = 1;
-const int FeedBackServo::q2min = unitsFC / 4;
-const int FeedBackServo::q3max = q2min * 3;
+const int FeedBackServo::q2min = FeedBackServo::unitsFC / 4;
+const int FeedBackServo::q3max = FeedBackServo::q2min * 3;
 
 FeedBackServo* FeedBackServo::instances[6] = { nullptr };
 

--- a/src/FeedBackServo.cpp
+++ b/src/FeedBackServo.cpp
@@ -59,6 +59,16 @@ void FeedBackServo::setKp(float _Kp)
     FeedBackServo::Kp = _Kp;
 }
 
+void FeedBackServo::SetActive(bool isActive)
+{
+    isActive_ = isActive;
+}
+
+void FeedBackServo::SetTarget(int target)
+{
+    targetAngle_ = target;
+}
+
 void FeedBackServo::rotate(int degree, int threshold)
 {
     float output, offset, value;
@@ -82,6 +92,25 @@ void FeedBackServo::rotate(int degree, int threshold)
         Parallax.writeMicroseconds(1490 - value);
     }
     Parallax.writeMicroseconds(1490);
+}
+
+
+void FeedBackServo::Update(int threshold = 4)
+{
+    if (isActive_ == false) return;
+
+    int errorAngle = targetAngle_ - angle_;
+    if (abs(errorAngle) <= threshold)
+    {
+        servo.writeMicroseconds(1490);
+        return;
+    }
+
+    float output = constrain(errorAngle * Kp_, -200.0, 200.0);
+    float offset = (errorAngle > 0) ? 30.0 : -30.0;
+    float value = output + offset;
+
+    servo.writeMicroseconds(1490 - value);
 }
 
 int FeedBackServo::Angle()

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -8,29 +8,29 @@ class FeedBackServo
 {
 public:
     FeedBackServo(byte feedbackPinNumber);
-    void setServoControl(byte servoPinNumber = 3);
-    void setKp(float _Kp = 1.0);
+    void SetServoControl(byte servoPinNumber = 3);
+    void SetKp(float Kp = 1.0);
     void SetActive(bool isActive);
     void SetTarget(int target);
     void Update(int threshold = 4);
     int Angle();
 
 private:
-    void pinCheck(byte pinNumber);
+    void CheckPin(byte pinNumber);
     void HandleFeedback();
     Servo Parallax;
     byte feedbackPinNumber;
     byte interruptNumber;
 
-    int targetAngle_;
+    float Kp_ = 1.0;
     bool isActive_ = true;
+    int targetAngle_;
 
     volatile int angle = 0;
     float thetaPre = 0;
     unsigned int tHigh = 0, tLow = 0;
     unsigned long rise = 0, fall = 0;
     int turns = 0;
-    float Kp = 1.0;
 
     static const int unitsFC = 360;
     static const float dcMin;

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -26,7 +26,7 @@ private:
     bool isActive_ = true;
     int targetAngle_;
 
-    volatile int angle = 0;
+    volatile int angle_ = 0;
     float thetaPre = 0;
     unsigned int tHigh = 0, tLow = 0;
     unsigned long rise = 0, fall = 0;

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -12,7 +12,6 @@ public:
     void setKp(float _Kp = 1.0);
     void SetActive(bool isActive);
     void SetTarget(int target);
-    void rotate(int degree, int threshold = 4);
     void Update(int threshold = 4);
     int Angle();
 

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -1,12 +1,13 @@
 #ifndef FEEDBACK360_CONTROL_LIBRARY
 #define FEEDBACK360_CONTROL_LIBRARY
+
 #include <Arduino.h>
 #include <Servo.h>
 
 class FeedBackServo
 {
 public:
-    FeedBackServo(byte feedbackPinNumber = 2);
+    FeedBackServo(byte feedbackPinNumber);
     void setServoControl(byte servoPinNumber = 3);
     void setKp(float _Kp = 1.0);
     void rotate(int degree, int threshold = 4);
@@ -14,9 +15,10 @@ public:
 
 private:
     void pinCheck(byte pinNumber);
-    void static feedback();
-    static Servo Parallax;
-    static byte feedbackPinNumber;
+    void HandleFeedback();
+    Servo Parallax;
+    byte feedbackPinNumber;
+    byte interruptNumber;
     static volatile int angle;
     static float thetaPre;
     static unsigned int tHigh, tLow;
@@ -29,6 +31,14 @@ private:
     static const int dutyScale;
     static const int q2min;
     static const int q3max;
+
+    static FeedBackServo* instances[6];
+    static void isr0();
+    static void isr1();
+    static void isr2();
+    static void isr3();
+    static void isr4();
+    static void isr5();
 };
 
 #endif

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -10,7 +10,10 @@ public:
     FeedBackServo(byte feedbackPinNumber);
     void setServoControl(byte servoPinNumber = 3);
     void setKp(float _Kp = 1.0);
+    void SetActive(bool isActive);
+    void SetTarget(int target);
     void rotate(int degree, int threshold = 4);
+    void Update(int threshold = 4);
     int Angle();
 
 private:

--- a/src/FeedBackServo.h
+++ b/src/FeedBackServo.h
@@ -21,16 +21,21 @@ private:
     Servo Parallax;
     byte feedbackPinNumber;
     byte interruptNumber;
-    static volatile int angle;
-    static float thetaPre;
-    static unsigned int tHigh, tLow;
-    static unsigned long rise, fall;
-    static int turns;
-    static float Kp;
-    static const int unitsFC;
+
+    int targetAngle_;
+    bool isActive_ = true;
+
+    volatile int angle = 0;
+    float thetaPre = 0;
+    unsigned int tHigh = 0, tLow = 0;
+    unsigned long rise = 0, fall = 0;
+    int turns = 0;
+    float Kp = 1.0;
+
+    static const int unitsFC = 360;
     static const float dcMin;
     static const float dcMax;
-    static const int dutyScale;
+    static const int dutyScale = 1;
     static const int q2min;
     static const int q3max;
 


### PR DESCRIPTION
**Enable simultaneous control of multiple Feedback360 servos**

- Refactored src/FeedBackServo.h and .cpp to support multiple motors
  - Removed static declarations of angle and other variables that should be instance-specific
- Introduced non-blocking P-control using Update() to be called from loop()
- This allows parallel-like control of multiple servos without blocking
- Added example sketch (MultiMotors.ino) demonstrating concurrent control
- Verified parallel control using Arduino UNO and two Feedback360 servos

**複数のFeedback360サーボの同時制御**

- src内の.hおよび.cppファイルに変更を加え、複数モーターの同時制御を可能にしました
  - モーターごとに異なる値を持つ angle などの変数が static だったため、複数制御できなかったと考えられます
- loop() 内で Update() を呼び出す非ブロッキング型にし、擬似並列制御を可能にしました
- 複数台同時P制御の挙動を確認できる MultiMotors.ino を追加しました
- Arduino UNO + モーター2台で動作確認